### PR TITLE
change build to have multiple tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,6 @@
 *.gitignore~
 *makefile~
 
-# Visual Studio Code Project Directory
-.vscode
-
 #don't push contents of build or SFML, it's all junk
 build/*
 SFML/*

--- a/.vscode/build_cmake.bat
+++ b/.vscode/build_cmake.bat
@@ -1,0 +1,4 @@
+set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+set SFML_DIR=..\SFML
+
+cmake -G "MinGW Makefiles" ..

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "program": "${workspaceRoot}/build/pong",
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "preLaunchTask": "build game",
+            "linux": {
+                "cwd": "${workspaceFolder}/build",
+                "program": "${workspaceFolder}/build/pong",
+            },
+            "windows": {
+                "cwd": "${workspaceFolder}\\build\\",
+                "program": "${workspaceFolder}\\build\\pong.exe",
+                "miDebuggerPath": "C:\\MinGW\\bin\\gdb.exe"
+            },
+            "args": [],
+            "stopAtEntry": false,
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "name": "(gdb) Launch",
             "type": "cppdbg",
             "request": "launch",
-            "preLaunchTask": "build game",
+            // "preLaunchTask": "build game",
             "linux": {
                 "cwd": "${workspaceFolder}/build",
                 "program": "${workspaceFolder}/build/pong",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,13 +13,7 @@
                 "command": "cmake ..",
             },
             "windows": {
-                "options": {
-                    "env": {
-                        "PATH": "%PATH:C:\\Program Files\\Git\\usr\\bin;=%",
-                        "SFML_DIR": "..\\SFML"
-                    }
-                },
-                "command": "cmake -G \"MinGW Makefiles\" .."
+                "command": "../.vscode/build_cmake"
             }
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,7 +32,6 @@
                     "cwd": "${workspaceFolder}/build"
                 }
             },
-            "problemMatcher": "$gcc",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,32 +4,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "copy assets",
-            "type": "shell",
-            "options": {
-                "cwd": "${workspaceFolder}/build"
-            },
-            "linux": {
-                "command": "cp -r ../assets ."
-            },
-            "windows": {
-                "command": "xcopy /y ..\\assets .\\"
-            },
-        },
-        {
-            "label": "copy dlls",
-            "type": "shell",
-            "options": {
-                "cwd": "${workspaceFolder}/build"
-            },
-            "linux": {
-                "command": ""
-            },
-            "windows": {
-                "command": "xcopy /y ..\\SFML\\bin\\*.dll .\\"
-            }
-        },
-        {
             "label": "cmake",
             "type": "shell",
             "options": {
@@ -51,7 +25,7 @@
         {
             "label": "build game",
             "type": "shell",
-            "dependsOn": ["copy assets", "copy dlls", "cmake"],
+            "dependsOn": ["cmake"],
             "linux": {
                 "command": "make",
                 "options": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,74 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "copy assets",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "linux": {
+                "command": "cp -r ../assets ."
+            },
+            "windows": {
+                "command": "xcopy /y ..\\assets .\\"
+            },
+        },
+        {
+            "label": "copy dlls",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "linux": {
+                "command": ""
+            },
+            "windows": {
+                "command": "xcopy /y ..\\SFML\\bin\\*.dll .\\"
+            }
+        },
+        {
+            "label": "cmake",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "linux": {
+                "command": "cmake ..",
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "%PATH:C:\\Program Files\\Git\\usr\\bin;=%",
+                        "SFML_DIR": "..\\SFML"
+                    }
+                },
+                "command": "cmake -G \"MinGW Makefiles\" .."
+            }
+        },
+        {
+            "label": "build game",
+            "type": "shell",
+            "dependsOn": ["copy assets", "copy dlls", "cmake"],
+            "linux": {
+                "command": "make",
+                "options": {
+                    "cwd": "${workspaceFolder}/build"
+                }
+            },
+            "windows": {
+                "command": "mingw32-make",
+                "options": {
+                    "cwd": "${workspaceFolder}/build"
+                }
+            },
+            "problemMatcher": "$gcc",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,8 @@ find_package(SFML 2.5 COMPONENTS graphics audio REQUIRED)
 
 add_executable(pong ${SOURCES} )
 target_link_libraries(pong sfml-graphics sfml-audio)
+
+file(COPY assets DESTINATION ${CMAKE_BINARY_DIR})
+
+file(GLOB SFML_DLL "SFML/*.dll")
+file(COPY ${SFML_DLL} DESTINATION ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,5 +17,5 @@ target_link_libraries(pong sfml-graphics sfml-audio)
 
 file(COPY assets DESTINATION ${CMAKE_BINARY_DIR})
 
-file(GLOB SFML_DLL "SFML/*.dll")
+file(GLOB SFML_DLL "SFML/bin/*.dll")
 file(COPY ${SFML_DLL} DESTINATION ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
I changed the VS Code build tasks to remove the need of a batch file in Windows. The commands have been separated into smaller composable tasks.

Also, VS Code tasks are not generated automatically by a tool like .sln files or Makefiles so they should be part of the source code.
